### PR TITLE
Events are added before map is loaded

### DIFF
--- a/src/components/AzureMap/AzureMap.tsx
+++ b/src/components/AzureMap/AzureMap.tsx
@@ -68,11 +68,12 @@ const AzureMap = memo(
         if (cameraOptions) {
           mref.setCamera(cameraOptions)
         }
+        for (const eventType in events) {
+          mref.events.add(eventType as any, events[eventType])
+        }
+        
         setMapReady(true)
       })
-      for (const eventType in events) {
-        mref.events.add(eventType as any, events[eventType])
-      }
     })
 
     useEffect(() => {


### PR DESCRIPTION
Events are added before the map is loaded.

This will throw an error that addEventListener is not a function